### PR TITLE
Fix dungeon restoration display

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -77,7 +77,12 @@ function loadGame() {
         refreshEquipmentScreen();
 
         // Ensure that the player's position is reflected correctly
-        displayCurrentScene();  // This should now handle the correct placement of 'P'
+        if (currentDungeon) {
+            displayDungeon();
+            displayDungeonScene();
+        } else {
+            displayCurrentScene();  // This should now handle the correct placement of 'P'
+        }
         updateMovementButtons();
         isCharacterCreated = true;
 


### PR DESCRIPTION
## Summary
- fix `loadGame` to show dungeon UI after loading a save

## Testing
- `node --check saveLoad.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cf59af10c8331a33e8695ea8e6345