### PR TITLE
Randomize dungeon IDs

### DIFF
--- a/dungeons.js
+++ b/dungeons.js
@@ -154,7 +154,7 @@ function generateDungeon() {
     // Place tiles based on dungeon type, similar to overworld scene placement
     fillDungeonScenes(dungeonMap, dungeonScenesArray, dungeonType, rng);
 
-    const dungeonId = `dungeon_${Date.now()}`; // Unique ID for the dungeon
+    const dungeonId = `dungeon_${Date.now()}_${Math.floor(Math.random()*1e6)}`; // Unique ID with random component
 
     dungeons[dungeonId] = {
         type: dungeonType,


### PR DESCRIPTION
## Summary
- incorporate a random number component into dungeon IDs
- keep storage and retrieval of IDs untouched, ensuring compatibility

## Testing
- `node -c dungeons.js`

------
https://chatgpt.com/codex/tasks/task_e_684cf6458ce88331a2ba6107a86eed09