### PR TITLE
Enable dungeon quest events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Echoes Dungeon Quest Testing
+
+This repository contains the code for the browser-based RPG "Echoes". The
+following steps demonstrate how to verify that dungeon quest events, such as
+**"Relic of the Lost Temple"**, can be encountered when their quest is active.
+
+## Manual Test Steps
+
+1. Open `index.html` in a modern web browser.
+2. Use the console (F12) to modify the player's active quests:
+   ```javascript
+   playerStats.activeQuests = [
+       { title: "Relic of the Lost Temple", completed: false }
+   ];
+   ```
+3. Enter any dungeon and move until a random event triggers. The event
+   "Relic of the Lost Temple" should appear in the rotation of dungeon events.
+4. Interact with the event to verify quest progress.
+
+These steps confirm that dungeon quest events are included when their
+corresponding quest is active.

--- a/events.js
+++ b/events.js
@@ -1848,15 +1848,26 @@ function getRandomEventFromDungeon(terrain) {
     }
 
     const filteredEvents = dungeonEvents.filter(event => event.terrain.includes(terrain));
-    if (filteredEvents.length === 0) {
+
+    let combinedEvents = filteredEvents;
+
+    if (playerStats.activeQuests && playerStats.activeQuests.length > 0) {
+        const activeQuestTitles = playerStats.activeQuests.map(quest => quest.title);
+        const questFilteredEvents = questEvents.filter(event =>
+            event.terrain.includes(terrain) && activeQuestTitles.includes(event.relatedQuest)
+        );
+        combinedEvents = [...filteredEvents, ...questFilteredEvents];
+    }
+
+    if (combinedEvents.length === 0) {
         console.warn("No events found for the terrain:", terrain);
         return null;
     }
-    
-    const totalWeight = filteredEvents.reduce((sum, event) => sum + (event.weight || 1), 0);
+
+    const totalWeight = combinedEvents.reduce((sum, event) => sum + (event.weight || 1), 0);
     let randomWeight = Math.random() * totalWeight;
 
-    for (let event of filteredEvents) {
+    for (let event of combinedEvents) {
         randomWeight -= event.weight;
         if (randomWeight <= 0) {
             return event;


### PR DESCRIPTION
## Summary
- allow dungeon event generator to include quest events when their quests are active
- document manual steps to verify dungeon quest event triggering

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_684cf90a799c8331b040ba1ea13d8641