### PR TITLE
Fix Guardian Shield level requirement

### DIFF
--- a/skills.js
+++ b/skills.js
@@ -74,7 +74,7 @@ const skills = {
         {
             name: "Guardian Shield",
             cost: 28,
-            level: 251,
+            level: 25,
             description: "Creates a protective shield around themselves, absorbing incoming damage.",
             execute: (player, enemy) => {
                 const shieldAmount = Math.round(player.STR * 0.6);


### PR DESCRIPTION
## Summary
- fix Knight's *Guardian Shield* skill unlock level
- verify skills available at level 25 using Node

## Testing
- `node - <<'NODE'
const vm=require('vm');
const fs=require('fs');
let ctx={};
vm.runInNewContext(fs.readFileSync('skills.js','utf8') + '\nglobalThis.skills = skills;', ctx);
function skillsAtLevel(level) {
  return ctx.skills['Knight'].filter(s => s.level <= level).map(s => s.name);
}
console.log('Skills at level 25:', skillsAtLevel(25));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_684cfc40a98083318ed7b0144be6546a