### PR TITLE
Improve enemy scaling with level

### DIFF
--- a/combat.js
+++ b/combat.js
@@ -101,9 +101,11 @@ const combat = {
         const randomEnemy = availableTiers[Math.floor(Math.random() * availableTiers.length)];
         const randomAdjective = enemyAdjectives[Math.floor(Math.random() * enemyAdjectives.length)];
     
-        // Apply scaling based on player level within the current tier
+        // Apply scaling based on player level. Scaling now increases
+        // beyond 1.0 as tiers advance.
         const levelWithinTier = Math.min(playerLevel % 5 || 5, 5);
-        const scalingFactor = 0.5 + (levelWithinTier - 1) * 0.1;
+        const tierBonus = 0.1 * Math.floor((playerLevel - 1) / 5);
+        const scalingFactor = 0.5 + (levelWithinTier - 1) * 0.1 + tierBonus;
     
         // Debugging to see which enemy is selected
         console.log("Selected enemy:", randomEnemy, "with adjective:", randomAdjective);


### PR DESCRIPTION
## Summary
- tune combat enemy scaling so later tiers exceed a factor of 1.0

## Testing
- `node - <<'NODE'
const fs=require('fs');const vm=require('vm');console.log=function(){};vm.runInThisContext(fs.readFileSync('enemies.js','utf8'));vm.runInThisContext(fs.readFileSync('combat.js','utf8'));const c=combat;for(let lvl of [1,6,11,16,21]){const e=c.getRandomEnemyFromPool(enemyTiers,lvl);console.error('Level',lvl,'Scaling HP',e.HP,'STR',e.STR);}NODE`

------
https://chatgpt.com/codex/tasks/task_e_684cfcdc4a30833198ef70460230f78e