### PR TITLE
Add deterministic RNG seed support

### DIFF
--- a/combat.js
+++ b/combat.js
@@ -109,8 +109,8 @@ const combat = {
         console.log("Available tiers based on player level:", playerLevel, availableTiers);
     
         // Choose a random enemy
-        const randomEnemy = availableTiers[Math.floor(Math.random() * availableTiers.length)];
-        const randomAdjective = enemyAdjectives[Math.floor(Math.random() * enemyAdjectives.length)];
+        const randomEnemy = availableTiers[Math.floor(getRandom() * availableTiers.length)];
+        const randomAdjective = enemyAdjectives[Math.floor(getRandom() * enemyAdjectives.length)];
     
         // Apply scaling based on player level. Scaling now increases
         // beyond 1.0 as tiers advance.
@@ -330,7 +330,7 @@ const combat = {
 
     run() {
         const runSuccessChance = Math.min(0.5 + this.getModifiedStat(this.player, 'LCK') / 100, 0.9);
-        if (Math.random() < runSuccessChance) {
+        if (getRandom() < runSuccessChance) {
             this.endCombat("You successfully escaped the battle!");
             lastEventTriggered = 'scene';
         } else {
@@ -352,13 +352,13 @@ const combat = {
         const defenseStat = isMagic ? 'ARC' : 'DEF';
         const baseAttack = this.getModifiedStat(attacker, baseAttackStat);
         const defense = this.getModifiedStat(defender, defenseStat);
-        const randomFactor = Math.random() * 0.2 + 0.9;
+        const randomFactor = getRandom() * 0.2 + 0.9;
         const criticalHitChance = Math.min(this.getModifiedStat(attacker, 'LCK') / 100, 0.5);
-        const isCriticalHit = Math.random() < criticalHitChance;
+        const isCriticalHit = getRandom() < criticalHitChance;
         const criticalHitMultiplier = isCriticalHit ? 2.0 : 1.0;
         const evasionChance = this.getModifiedStat(defender, 'EVD') / 100;
 
-        if (Math.random() < evasionChance && !isSkill) {
+        if (getRandom() < evasionChance && !isSkill) {
             return { damage: 0, evaded: true, critical: false };
         }
 
@@ -509,7 +509,7 @@ const combat = {
         let rewardsMessage = `<h3>Battle Rewards</h3>`;
         rewardsMessage += `<p>XP Gained: ${this.enemy.XP}</p>`;
 
-        const coinsGained = Math.floor(Math.random() * (this.enemy.coinRange.max - this.enemy.coinRange.min + 1)) + this.enemy.coinRange.min;
+        const coinsGained = Math.floor(getRandom() * (this.enemy.coinRange.max - this.enemy.coinRange.min + 1)) + this.enemy.coinRange.min;
         playerStats.coins += coinsGained;
 
         rewardsMessage += `<p>Coins Gained: ${coinsGained}</p>`;
@@ -517,7 +517,7 @@ const combat = {
         if (this.enemy.drops && this.enemy.drops.length > 0) {
             rewardsMessage += `<p>Items Gained:</p><ul>`;
             this.enemy.drops.forEach(drop => {
-                if (Math.random() < drop.rate) {
+                if (getRandom() < drop.rate) {
                     const item = getItemDefinition(drop.item);
                     if (item) {
                         rewardsMessage += `<li>${item.name}</li>`;

--- a/dungeons.js
+++ b/dungeons.js
@@ -84,7 +84,7 @@ const cavernsScenes = [
 ];
 
 function getRandomElement(arr) {
-    return arr[Math.floor(Math.random() * arr.length)];
+    return arr[Math.floor(getRandom() * arr.length)];
 }
 
 function getDungeonEntrance(dungeonType) {
@@ -105,7 +105,7 @@ function getDungeonScenes(dungeonType) {
 
 function generateDungeon() {
     // Generate a unique seed for this dungeon
-    const dungeonSeed = Date.now().toString() + Math.random().toString();
+    const dungeonSeed = Date.now().toString() + getRandom().toString();
     const rng = new Math.seedrandom(dungeonSeed); // Initialize rng correctly
 
     const dungeonType = rng() < 0.5 ? 'ruins' : 'caverns';
@@ -154,7 +154,7 @@ function generateDungeon() {
     // Place tiles based on dungeon type, similar to overworld scene placement
     fillDungeonScenes(dungeonMap, dungeonScenesArray, dungeonType, rng);
 
-    const dungeonId = `dungeon_${Date.now()}_${Math.floor(Math.random()*1e6)}`; // Unique ID with random component
+    const dungeonId = `dungeon_${Date.now()}_${Math.floor(getRandom()*1e6)}`; // Unique ID with random component
 
     dungeons[dungeonId] = {
         type: dungeonType,
@@ -412,7 +412,7 @@ function triggerDungeonEvent() {
     }
 
     // Introduce a random chance for the event to trigger
-    const eventChance = Math.random();
+    const eventChance = getRandom();
     if (eventChance < 0.3) { // 30% chance to trigger an event (adjust as needed)
         const event = getRandomEventFromDungeon(scene.terrain); // Call the function from events.js
         if (!event) {

--- a/equipment.js
+++ b/equipment.js
@@ -490,14 +490,14 @@ organizeEquipment();
 function getRandomEquipmentByTier(tier) {
     const tierEquipment = equipmentByTier[tier] || [];
     if (tierEquipment.length === 0) return null;
-    const randomIndex = Math.floor(Math.random() * tierEquipment.length);
+    const randomIndex = Math.floor(getRandom() * tierEquipment.length);
     return tierEquipment[randomIndex];
 }
 
 function getRandomEquipmentByType(type) {
     const typeEquipment = equipmentByType[type] || [];
     if (typeEquipment.length === 0) return null;
-    const randomIndex = Math.floor(Math.random() * typeEquipment.length);
+    const randomIndex = Math.floor(getRandom() * typeEquipment.length);
     return typeEquipment[randomIndex];
 }
 
@@ -507,7 +507,7 @@ function getRandomEquipmentByTierAndType(tiers, excludeTypes = []) {
         (!equip.types || !excludeTypes.some(type => equip.types.includes(type)))
     );
     if (!tierEquipment.length) return null;
-    return tierEquipment[Math.floor(Math.random() * tierEquipment.length)];
+    return tierEquipment[Math.floor(getRandom() * tierEquipment.length)];
 }
 
 function getRandomEquipment(min, max, tiers = []) {
@@ -516,7 +516,7 @@ function getRandomEquipment(min, max, tiers = []) {
     for (let i = 0; i < equipmentCount; i++) {
         let equip = null;
         if (tiers.length > 0) {
-            const tier = tiers[Math.floor(Math.random() * tiers.length)];
+            const tier = tiers[Math.floor(getRandom() * tiers.length)];
             equip = getRandomEquipmentByTier(tier);
         }
         if (equip) {

--- a/events.js
+++ b/events.js
@@ -218,7 +218,7 @@ const events = [
         weight: 1,
         terrain: ["forest", "field", "path"],
         action: function() {
-            const item = Math.random() < 0.2 ? items.find(i => i.name === "Tent") : getRandomItemByTier(1) || getRandomItemByTier(2);
+            const item = getRandom() < 0.2 ? items.find(i => i.name === "Tent") : getRandomItemByTier(1) || getRandomItemByTier(2);
             addItemToInventory(item);
             displayEventEffect(this.name, this.description, `The lost merchant gives you a ${item.name} as thanks.`);
         }
@@ -333,7 +333,7 @@ const events = [
         terrain: ["path", "forest"],
         action: function () {
             const rareItems = ["Cursed Amulet", "Enchanted Mirror"];
-            const requestedItem = rareItems[Math.floor(Math.random() * rareItems.length)];
+            const requestedItem = rareItems[Math.floor(getRandom() * rareItems.length)];
             const item = inventory.find(i => i.name === requestedItem);
             if (item) {
                 const coins = getRandomInt(5, 15);
@@ -405,7 +405,7 @@ const events = [
                 return;
             }
 
-            const bounty = Math.floor(Math.random() * 91) + 10;
+            const bounty = Math.floor(getRandom() * 91) + 10;
             const controlWindow = document.getElementById('control-window');
             if (controlWindow) {
                 controlWindow.style.visibility = 'hidden';
@@ -495,7 +495,7 @@ const questEvents = [
         relatedQuest: "Lost Necklace",
         action: function() {
             // Check luck to determine if the player can collect the necklace without trouble
-            const luckCheck = Math.random() < playerStats.LCK / 100;
+            const luckCheck = getRandom() < playerStats.LCK / 100;
             if (luckCheck) {
                 displayQuestResult(
                     this.relatedQuest,
@@ -579,7 +579,7 @@ const questEvents = [
             // Define approach functions with results for each option
             approachOptions.forEach(({ name, stat, successMessage, failMessage }) => {
                 window[name] = () => {
-                    const success = Math.random() < playerStats[stat] / 100;
+                    const success = getRandom() < playerStats[stat] / 100;
                     displayQuestResult(
                         this.relatedQuest, 
                         success, 
@@ -632,7 +632,7 @@ const questEvents = [
             
             // Function for identifying herbs using ARC check
             window.identifyHerbs = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -652,7 +652,7 @@ const questEvents = [
             
             // Function for speedy collection using EVD check
             window.speedyCollection = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -713,7 +713,7 @@ const questEvents = [
             
             // Attempt to exorcise the spirit using ARC check
             window.exorciseSpirit = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -733,7 +733,7 @@ const questEvents = [
             
             // Attempt to flee using EVD check
             window.fleeArea = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -782,7 +782,7 @@ const questEvents = [
 
             // Assist with Construction - STR check
             window.assistWithConstruction = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -803,7 +803,7 @@ const questEvents = [
 
             // Assist with Planning - ARC check
             window.assistWithPlanning = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -845,7 +845,7 @@ const questEvents = [
     
             // Stealth recovery using EVD check
             window.recoverGoodsStealth = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
     
                 if (evasionCheck) {
                     displayQuestResult(
@@ -865,7 +865,7 @@ const questEvents = [
     
             // Intimidation using STR check
             window.intimidateThieves = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
     
                 if (strengthCheck) {
                     displayQuestResult(
@@ -885,7 +885,7 @@ const questEvents = [
     
             // Persuasion using ARC check
             window.convinceThieves = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
     
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -946,7 +946,7 @@ const questEvents = [
 
             // Attempt to purify the water using ARC check
             window.purifyWater = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -966,7 +966,7 @@ const questEvents = [
             
             // Investigate the source of the poison using EVD check
             window.investigateSource = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -986,7 +986,7 @@ const questEvents = [
             
             // Construct a filter using STR check
             window.constructFilter = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -1063,7 +1063,7 @@ const questEvents = [
 
             // Search the area using EVD check
             window.searchArea = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -1083,7 +1083,7 @@ const questEvents = [
 
             // Investigate tracks using ARC check
             window.investigateTracks = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -1103,7 +1103,7 @@ const questEvents = [
 
             // Wrangle livestock using STR check
             window.wrangleLivestock = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -1144,7 +1144,7 @@ const questEvents = [
 
             // Sneak Closer - EVD Check
             document.getElementById('sneakButton').addEventListener('click', function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 if (evasionCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1161,7 +1161,7 @@ const questEvents = [
 
             // Analyze with Magic - ARC Check
             document.getElementById('magicButton').addEventListener('click', function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 if (arcaneCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1229,7 +1229,7 @@ const questEvents = [
 
             // Investigate symbols using ARC check
             window.investigateSymbols = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -1252,7 +1252,7 @@ const questEvents = [
 
             // Perform ritual using EVD check
             window.performRitual = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -1274,7 +1274,7 @@ const questEvents = [
 
             // Destroy site using STR check
             window.destroySite = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -1316,7 +1316,7 @@ const questEvents = [
 
             // Defend the merchant using STR check
             window.defendMerchant = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -1337,7 +1337,7 @@ const questEvents = [
 
             // Guide the merchant using ARC check
             window.guideMerchant = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -1358,7 +1358,7 @@ const questEvents = [
 
             // Negotiate with bandits using LCK check
             window.negotiateBandits = function() {
-                const luckCheck = Math.random() < playerStats.LCK / 100;
+                const luckCheck = getRandom() < playerStats.LCK / 100;
                 
                 if (luckCheck) {
                     displayQuestResult(
@@ -1399,7 +1399,7 @@ const questEvents = [
 
             // Search for rare ingredients using EVD check
             window.searchIngredients = function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 
                 if (evasionCheck) {
                     displayQuestResult(
@@ -1419,7 +1419,7 @@ const questEvents = [
 
             // Gather the final ingredient using STR check
             window.gatherFinalIngredient = function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 
                 if (strengthCheck) {
                     displayQuestResult(
@@ -1439,7 +1439,7 @@ const questEvents = [
 
             // Prepare the cure using ARC check
             window.prepareCure = function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 
                 if (arcaneCheck) {
                     displayQuestResult(
@@ -1497,7 +1497,7 @@ const questEvents = [
 
             // Disarm the traps using EVD check
             document.getElementById('disarmTraps').addEventListener('click', function() {
-                const evasionCheck = Math.random() < playerStats.EVD / 100;
+                const evasionCheck = getRandom() < playerStats.EVD / 100;
                 if (evasionCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1514,7 +1514,7 @@ const questEvents = [
 
             // Retrieve the relic directly using STR check
             document.getElementById('retrieveRelic').addEventListener('click', function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 if (strengthCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1531,7 +1531,7 @@ const questEvents = [
 
             // Study the relic using ARC check
             document.getElementById('studyRelic').addEventListener('click', function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 if (arcaneCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1589,7 +1589,7 @@ const questEvents = [
 
             // Break the curse using ARC check
             document.getElementById('breakCurse').addEventListener('click', function() {
-                const arcaneCheck = Math.random() < playerStats.ARC / 100;
+                const arcaneCheck = getRandom() < playerStats.ARC / 100;
                 if (arcaneCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1606,7 +1606,7 @@ const questEvents = [
 
             // Endure the curse using STR check
             document.getElementById('endureCurse').addEventListener('click', function() {
-                const strengthCheck = Math.random() < playerStats.STR / 100;
+                const strengthCheck = getRandom() < playerStats.STR / 100;
                 if (strengthCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1628,7 +1628,7 @@ const questEvents = [
 
             // Dispel the curse using LCK check
             document.getElementById('dispelCurse').addEventListener('click', function() {
-                const luckCheck = Math.random() < playerStats.LCK / 100;
+                const luckCheck = getRandom() < playerStats.LCK / 100;
                 if (luckCheck) {
                     displayQuestResult(
                         relatedQuestName,
@@ -1827,7 +1827,7 @@ function getRandomEvent(terrain) {
     const filteredEvents = events.filter(event => event.terrain.includes(terrain));
 
     if (!playerStats.activeQuests || playerStats.activeQuests.length === 0) {
-        return filteredEvents.length > 0 ? filteredEvents[Math.floor(Math.random() * filteredEvents.length)] : null;
+        return filteredEvents.length > 0 ? filteredEvents[Math.floor(getRandom() * filteredEvents.length)] : null;
     }
 
     const activeQuestTitles = playerStats.activeQuests.map(quest => quest.title);
@@ -1838,7 +1838,7 @@ function getRandomEvent(terrain) {
 
     const combinedEvents = [...filteredEvents, ...questFilteredEvents];
 
-    return combinedEvents.length > 0 ? combinedEvents[Math.floor(Math.random() * combinedEvents.length)] : null;
+    return combinedEvents.length > 0 ? combinedEvents[Math.floor(getRandom() * combinedEvents.length)] : null;
 }
 
 function getRandomEventFromDungeon(terrain) {
@@ -1865,7 +1865,7 @@ function getRandomEventFromDungeon(terrain) {
     }
 
     const totalWeight = combinedEvents.reduce((sum, event) => sum + (event.weight || 1), 0);
-    let randomWeight = Math.random() * totalWeight;
+    let randomWeight = getRandom() * totalWeight;
 
     for (let event of combinedEvents) {
         randomWeight -= event.weight;
@@ -1968,7 +1968,7 @@ function augmentEquipmentFromEvent(slot, requiredItemName, requiredQuantity) {
 }
 
 function calculateEventEffect(baseAmount, type) {
-    const luckRoll = Math.random(); // A roll between 0 and 1
+    const luckRoll = getRandom(); // A roll between 0 and 1
     const luckThreshold = playerStats.LCK / 100; // Assuming LCK is out of 100
     let result = 'pass';
 

--- a/items.js
+++ b/items.js
@@ -248,21 +248,21 @@ organizeItems();
 function getRandomItemByTier(tier) {
     const tierItems = itemsByTier[tier] || [];
     if (tierItems.length === 0) return null;
-    const randomIndex = Math.floor(Math.random() * tierItems.length);
+    const randomIndex = Math.floor(getRandom() * tierItems.length);
     return tierItems[randomIndex];
 }
 
 function getRandomItemByType(type) {
     const typeItems = itemsByType[type] || [];
     if (typeItems.length === 0) return null;
-    const randomIndex = Math.floor(Math.random() * typeItems.length);
+    const randomIndex = Math.floor(getRandom() * typeItems.length);
     return typeItems[randomIndex];
 }
 
 function getRandomItemByTierAndType(tiers, excludeTypes = []) {
     const tierItems = items.filter(item => tiers.includes(item.tier) && !excludeTypes.some(type => item.types.includes(type)));
     if (!tierItems.length) return null;
-    return tierItems[Math.floor(Math.random() * tierItems.length)];
+    return tierItems[Math.floor(getRandom() * tierItems.length)];
 }
 
 function getItemsExcludingTypes(excludedTypes) {
@@ -275,10 +275,10 @@ function getRandomItems(min, max, tiers = [], types = []) {
     for (let i = 0; i < itemCount; i++) {
         let item = null;
         if (tiers.length > 0) {
-            const tier = tiers[Math.floor(Math.random() * tiers.length)];
+            const tier = tiers[Math.floor(getRandom() * tiers.length)];
             item = getRandomItemByTier(tier);
         } else if (types.length > 0) {
-            const type = types[Math.floor(Math.random() * types.length)];
+            const type = types[Math.floor(getRandom() * types.length)];
             item = getRandomItemByType(type);
         }
         if (item && !item.types.includes("Currency")) {
@@ -289,6 +289,6 @@ function getRandomItems(min, max, tiers = [], types = []) {
 }
 
 function getRandomCoin() {
-    return coins[Math.floor(Math.random() * coins.length)];
+    return coins[Math.floor(getRandom() * coins.length)];
 }
 

--- a/map.js
+++ b/map.js
@@ -133,7 +133,7 @@ function distributeDungeons(maxDungeons) {
         const x = getRandomInt(1, MAP_SIZE - 2);
         const y = getRandomInt(1, MAP_SIZE - 2);
         if (map[y][x] === '.') {
-            const dungeonSeed = Date.now().toString() + Math.random().toString();
+            const dungeonSeed = Date.now().toString() + getRandom().toString();
             const dungeonId = generateDungeon(dungeonSeed);  // Pass the unique seed
 
             const dungeon = dungeons[dungeonId]; // Retrieve the dungeon object using the ID
@@ -418,7 +418,7 @@ function displayScene(x, y) {
     const storedScene = scenesArray[y][x];
     console.log("Current Scene:", storedScene);  // Properly log the current scene
     const terrain = storedScene ? storedScene.terrain : 'floor';
-    const isEvent = Math.random() < 0.3;
+    const isEvent = getRandom() < 0.3;
 
     // Handle town scenes
     if (storedScene && storedScene.type === 'town') {

--- a/quests.js
+++ b/quests.js
@@ -131,7 +131,7 @@ function generateNewQuestsForTown(townSource) {
 
     // Shuffle the available quests to ensure random selection
     for (let i = availableQuests.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(getRandom() * (i + 1));
         [availableQuests[i], availableQuests[j]] = [availableQuests[j], availableQuests[i]];
     }
 

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -14,7 +14,8 @@ function saveGame() {
         currentDungeonMap: currentDungeonMap, // Save current dungeon map
         dungeonScenesArray: dungeonScenesArray, // Save dungeon scenes
         dungeons: dungeons, // Save the entire dungeons object
-        dungeonPlayerPosition: { x: playerPosition.x, y: playerPosition.y }  // Save player's position in the dungeon
+        dungeonPlayerPosition: { x: playerPosition.x, y: playerPosition.y }, // Save player's position in the dungeon
+        seed: getCurrentSeed()
     };
 
     localStorage.setItem('saveData1', JSON.stringify(saveData));
@@ -40,8 +41,11 @@ function loadGame() {
             currentDungeonMap: loadedDungeonMap,    // Load current dungeon map
             dungeonScenesArray: loadedDungeonScenesArray, // Load dungeon scenes
             dungeons: loadedDungeons,  // Load the entire dungeons object
-            dungeonPlayerPosition: loadedDungeonPlayerPosition // Load player's position in the dungeon
+            dungeonPlayerPosition: loadedDungeonPlayerPosition, // Load player's position in the dungeon
+            seed: loadedSeed
         } = JSON.parse(savedData);
+
+        setRandomSeed(loadedSeed || Date.now().toString());
 
         // Assign loaded data to game variables
         playerStats = loadedPlayerStats;

--- a/scenes.js
+++ b/scenes.js
@@ -278,7 +278,7 @@ const scenes = [
 ];
 
 function getRandomScene() {
-    const randomIndex = Math.floor(Math.random() * scenes.length);
+    const randomIndex = Math.floor(getRandom() * scenes.length);
     return scenes[randomIndex];
 }
 
@@ -299,10 +299,10 @@ function selectSceneBasedOnTerrain(x, y, map, scenesArray) {
     }
 
     // Add randomness to occasionally place different terrains
-    if (Math.random() < 0.1) {
+    if (getRandom() < 0.1) {
         const randomTerrains = ['forest', 'field', 'water', 'mountain', 'ruins'];
-        const randomTerrain = randomTerrains[Math.floor(Math.random() * randomTerrains.length)];
-        return getScenesByTerrain(randomTerrain)[Math.floor(Math.random() * getScenesByTerrain(randomTerrain).length)];
+        const randomTerrain = randomTerrains[Math.floor(getRandom() * randomTerrains.length)];
+        return getScenesByTerrain(randomTerrain)[Math.floor(getRandom() * getScenesByTerrain(randomTerrain).length)];
     }
 
     const terrainCounts = neighboringTerrains.reduce((acc, terrain) => {
@@ -313,7 +313,7 @@ function selectSceneBasedOnTerrain(x, y, map, scenesArray) {
     const mostCommonTerrain = Object.keys(terrainCounts).reduce((a, b) => terrainCounts[a] > terrainCounts[b] ? a : b, null);
 
     const availableScenes = getScenesByTerrain(mostCommonTerrain);
-    return availableScenes.length > 0 ? availableScenes[Math.floor(Math.random() * availableScenes.length)] : getRandomScene();
+    return availableScenes.length > 0 ? availableScenes[Math.floor(getRandom() * availableScenes.length)] : getRandomScene();
 }
 
 function isPathNeighbor(x, y, map) {

--- a/script.js
+++ b/script.js
@@ -219,6 +219,8 @@ function startGame() {
         return;
     }
 
+    setRandomSeed(Date.now().toString());
+
     isCharacterCreated = true;
     enableControlWindow();
     document.querySelector('.info-window').style.visibility = 'visible';
@@ -366,7 +368,7 @@ function displayCurrentScene() {
 
     if (!isLoadingGame && isCharacterCreated) {
         // Only trigger events if the game is not being loaded and character is created
-        const isEvent = Math.random() < 0.3;
+        const isEvent = getRandom() < 0.3;
         if (isEvent && lastEventTriggered !== 'event') {
             const event = getRandomEvent();
             currentScene = { ...event, type: 'event' };
@@ -403,14 +405,14 @@ function showScreen(screen) {
     switch (screen) {
         case 'default':
             content = 'Welcome to Echoes of The Darkwood';
-            if (Math.random() < 0.3) {
+            if (getRandom() < 0.3) {
                 const event = getRandomEvent();
                 content = `
                     <h2>${event.name}</h2>
                     <p>${event.description}</p>
                 `;
                 applyEvent(event);
-            } else if (Math.random() < 0.2) {
+            } else if (getRandom() < 0.2) {
                 const town = generateTown();
                 content = `
                     <h2>Welcome to ${town.name}</h2>
@@ -872,6 +874,8 @@ function restartGame() {
     const playerName = playerStats.name; // Retain the player's name
     const playerClass = playerStats.class; // Retain the player's class
 
+    setRandomSeed(Date.now().toString());
+
     // Reinitialize player stats with the retained name and class
     initializePlayerStats(playerName, playerClass);
 
@@ -923,7 +927,7 @@ function restartGame() {
 
 // Define the getRandomValue function
 function getRandomValue(min, max) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+    return Math.floor(getRandom() * (max - min + 1)) + min;
 }
 
 function updatePlayerSkills() {

--- a/skills.js
+++ b/skills.js
@@ -9,11 +9,11 @@ const skills = {
                 const damage = Math.floor(combat.getModifiedStat(player, 'STR') * 1.2);
                 const stunChance = 0.2;
                 const criticalHitChance = Math.min(combat.getModifiedStat(player, 'LCK') / 100, 0.5);
-                const isCritical = Math.random() < criticalHitChance;
+                const isCritical = getRandom() < criticalHitChance;
                 
                 let message = `You bash the enemy with your shield for ${damage} damage.`;
                 
-                if (isCritical || Math.random() < stunChance) {
+                if (isCritical || getRandom() < stunChance) {
                     combat.applyEffect('Stun', enemy, 1);
                     message += " The enemy is stunned!";
                 }
@@ -53,7 +53,7 @@ const skills = {
             execute: (player, enemy) => {
                 let damage = Math.round(combat.getModifiedStat(player, 'STR') * 1.5);
                 const criticalBonus = 0.6;
-                const isCritical = Math.random() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
+                const isCritical = getRandom() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
                 if (isCritical) {
                     damage *= 2;
                 }
@@ -144,7 +144,7 @@ const skills = {
             execute: (player, enemy) => {
                 const damage = Math.round(combat.getModifiedStat(player, 'STR') * 2);
                 const criticalBonus = 0.75;
-                const isCritical = Math.random() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
+                const isCritical = getRandom() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
                 const finalDamage = isCritical ? damage * 2 : damage;
                 return { damage: finalDamage, message: `Assassinate deals ${finalDamage} damage with ${isCritical ? "a critical hit" : "no critical hit"}.` };
             }
@@ -160,7 +160,7 @@ const skills = {
                 const damage = Math.floor(combat.getModifiedStat(player, 'ARC') * 1.2);
                 const burnChance = 0.5;
                 let message = `You hurl a fireball at the enemy for ${damage} damage.`;
-                if (Math.random() < burnChance) {
+                if (getRandom() < burnChance) {
                     combat.applyEffect('Burn', enemy, 2);
                     message += " The enemy is burning!";
                 }
@@ -195,7 +195,7 @@ const skills = {
             description: "A powerful bolt of lightning strikes the enemy, dealing high damage with a chance to paralyze.",
             execute: (player, enemy) => {
                 const damage = Math.round(combat.getModifiedStat(player, 'ARC') * 1.5);
-                const isStunned = Math.random() < 0.5;
+                const isStunned = getRandom() < 0.5;
                 if (isStunned) {
                     combat.applyEffect('Stun', enemy, 1);
                 }
@@ -221,7 +221,7 @@ const skills = {
             description: "The Mage calls down a massive meteor to strike the enemy, dealing devastating damage.",
             execute: (player, enemy) => {
                 const damage = Math.round(combat.getModifiedStat(player, 'ARC') * 2);
-                const isBurned = Math.random() < 0.5;
+                const isBurned = getRandom() < 0.5;
                 if (isBurned) {
                     combat.applyEffect('Burn', enemy, 3);
                 }
@@ -280,7 +280,7 @@ const skills = {
             execute: (player, enemy) => {
                 const damage = Math.round(combat.getModifiedStat(player, 'ARC') * 1.5);
                 const criticalBonus = 0.75;
-                const isCritical = Math.random() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
+                const isCritical = getRandom() < (criticalBonus + (combat.getModifiedStat(player, 'LCK') / 100));
                 const finalDamage = isCritical ? damage * 2 : damage;
                 return { damage: finalDamage, message: `Righteous Fury deals ${finalDamage} damage with ${isCritical ? "a critical hit" : "no critical hit"}.` };
             }
@@ -292,7 +292,7 @@ const skills = {
             description: "The Cleric calls down a divine judgment on the enemy, dealing massive damage with a chance to stun.",
             execute: (player, enemy) => {
                 const damage = Math.round(combat.getModifiedStat(player, 'ARC') * 2);
-                const isStunned = Math.random() < 0.5;
+                const isStunned = getRandom() < 0.5;
                 if (isStunned) {
                     combat.applyEffect('Stun', enemy, 1);
                 }

--- a/tavern.js
+++ b/tavern.js
@@ -136,13 +136,13 @@ const tavernScenes = [
 ];
 
 function getRandomCharacter() {
-    const name = names[Math.floor(Math.random() * names.length)];
-    const profession = professions[Math.floor(Math.random() * professions.length)];
+    const name = names[Math.floor(getRandom() * names.length)];
+    const profession = professions[Math.floor(getRandom() * professions.length)];
     return { name: `${name} the ${profession}`, description: `${name} is a ${profession.toLowerCase()} in the town.` };
 }
 
 function getRandomGossip() {
-    const randomIndex = Math.floor(Math.random() * gossips.length);
+    const randomIndex = Math.floor(getRandom() * gossips.length);
     const conversation = gossips[randomIndex];
 
     // Determine the number of speakers needed
@@ -162,7 +162,7 @@ function getRandomGossip() {
 }
 
 function getRandomTavernScene() {
-    return tavernScenes[Math.floor(Math.random() * tavernScenes.length)];
+    return tavernScenes[Math.floor(getRandom() * tavernScenes.length)];
 }
 
 function enterTavern() {

--- a/towns.js
+++ b/towns.js
@@ -46,31 +46,31 @@ const townDescriptions = [
 ];
 
 function getRandomLocations(number) {
-    const shuffledLocations = allLocations.sort(() => 0.5 - Math.random());
+    const shuffledLocations = allLocations.sort(() => 0.5 - getRandom());
     return shuffledLocations.slice(0, number);
 }
 
 function getRandomTown() {
-    const prefix = townPrefixes[Math.floor(Math.random() * townPrefixes.length)];
-    const suffix = townSuffixes[Math.floor(Math.random() * townSuffixes.length)];
-    const size = Math.random();
+    const prefix = townPrefixes[Math.floor(getRandom() * townPrefixes.length)];
+    const suffix = townSuffixes[Math.floor(getRandom() * townSuffixes.length)];
+    const size = getRandom();
 
     let townName = `${prefix}${suffix}`;
     let townType;
     let locations;
 
     if (size < 0.33) {
-        townType = smallTownNames[Math.floor(Math.random() * smallTownNames.length)];
+        townType = smallTownNames[Math.floor(getRandom() * smallTownNames.length)];
         locations = getRandomLocations(3);
     } else if (size < 0.66) {
-        townType = mediumTownNames[Math.floor(Math.random() * mediumTownNames.length)];
+        townType = mediumTownNames[Math.floor(getRandom() * mediumTownNames.length)];
         locations = getRandomLocations(5);
     } else {
-        townType = largeTownNames[Math.floor(Math.random() * largeTownNames.length)];
+        townType = largeTownNames[Math.floor(getRandom() * largeTownNames.length)];
         locations = getRandomLocations(7);
     }
 
-    const descriptionTemplate = townDescriptions[Math.floor(Math.random() * townDescriptions.length)];
+    const descriptionTemplate = townDescriptions[Math.floor(getRandom() * townDescriptions.length)];
     const description = descriptionTemplate.replace('${townName}', townName).replace('${townType}', townType);
 
     return {
@@ -82,7 +82,7 @@ function getRandomTown() {
 
 function shuffleArray(array) {
     for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(getRandom() * (i + 1));
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,24 @@
+let rng = Math.random;
+let currentSeed = null;
+
+function setRandomSeed(seed) {
+    currentSeed = seed;
+    rng = new Math.seedrandom(seed);
+}
+
+function resetRandomSeed() {
+    currentSeed = null;
+    rng = Math.random;
+}
+
+function getCurrentSeed() {
+    return currentSeed;
+}
+
+function getRandom() {
+    return rng();
+}
+
 function getTiersByPlayerLevel(level) {
     if (level >= 1 && level <= 4) {
         return [1];
@@ -13,12 +34,12 @@ function getTiersByPlayerLevel(level) {
 }
 
 function getRandomInt(min, max) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+    return Math.floor(getRandom() * (max - min + 1)) + min;
 }
 
 function shuffleArray(array) {
     for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(getRandom() * (i + 1));
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;


### PR DESCRIPTION
## Summary
- wrap `Math.seedrandom` in new utils helpers
- replace `Math.random()` calls with `getRandom()`
- persist RNG seed in saves
- set the seed when starting or loading games

## Testing
- `node --check *.js`

------
https://chatgpt.com/codex/tasks/task_e_684d008e4a808331b38601d778a78023