### PR TITLE
Remove duplicate shuffleArray

### DIFF
--- a/towns.js
+++ b/towns.js
@@ -80,13 +80,7 @@ function getRandomTown() {
     };
 }
 
-function shuffleArray(array) {
-    for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(getRandom() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
-    }
-    return array;
-}
+// shuffleArray is defined in utils.js
 
 function visitInn() {
     const contentWindow = document.getElementById('content-window');


### PR DESCRIPTION
## Summary
- eliminate the local `shuffleArray` helper from `towns.js`
- rely on the shared implementation from `utils.js`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684d09317c788331a6301e633c908777