### PR TITLE
Fix showStartScreen state reset

### DIFF
--- a/__tests__/showStartScreen.test.js
+++ b/__tests__/showStartScreen.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const {JSDOM} = require('jsdom');
+const vm = require('vm');
+
+test('showStartScreen renders menu and resets state', () => {
+  const html = `
+    <div id="content-window"></div>
+    <div class="info-window"></div>
+    <div id="control-window" class="control-window"></div>
+  `;
+  const dom = new JSDOM(html, {runScripts: 'outside-only'});
+  const context = dom.getInternalVMContext();
+  // Prevent DOMContentLoaded side effects during tests
+  context.document.addEventListener = () => {};
+  context.window.addEventListener = () => {};
+  class LocalStorageMock {
+    constructor() { this.store = {}; }
+    getItem(key) { return this.store[key] || null; }
+    setItem(key, value) { this.store[key] = String(value); }
+    removeItem(key) { delete this.store[key]; }
+  }
+  Object.defineProperty(context, 'localStorage', {value: new LocalStorageMock(), writable: true});
+
+  // Load GameState and script into the JSDOM context
+  let gameStateSrc = fs.readFileSync(path.join(__dirname, '../GameState.js'), 'utf8');
+  gameStateSrc += '\n;globalThis.GameState = GameState;';
+  const scriptSrc = fs.readFileSync(path.join(__dirname, '../script.js'), 'utf8');
+  vm.runInContext(gameStateSrc, context);
+  vm.runInContext(scriptSrc, context);
+
+  context.showStartScreen();
+  const content = dom.window.document.getElementById('content-window').innerHTML;
+  expect(content).toMatch('New Game');
+  expect(dom.window.GameState.isCharacterCreated).toBe(false);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "echoes",
+  "version": "1.0.0",
+  "description": "Echoes of The Darkwood",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -117,6 +117,16 @@ function closeInfoModal() {
 
 // Character Creation
 function showStartScreen() {
+    // Reset basic game state values when returning to the start screen
+    isCharacterCreated = false;
+    GameState.isCharacterCreated = isCharacterCreated;
+    eventInProgress = false;
+    GameState.eventInProgress = eventInProgress;
+    currentScene = null;
+    GameState.currentScene = currentScene;
+    previousScreen = null;
+    GameState.previousScreen = previousScreen;
+
     const contentWindow = document.getElementById('content-window');
     disableControlWindow();
     contentWindow.innerHTML = `


### PR DESCRIPTION
## Summary
- reset game state in `showStartScreen` so returning to the main menu works
- add `package.json` with Jest for testing
- add unit test for `showStartScreen`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dbd4e14e483319d71194b7368bd68