### PR TITLE
Reset event state on start screen

### DIFF
--- a/__tests__/showStartScreen.test.js
+++ b/__tests__/showStartScreen.test.js
@@ -33,4 +33,5 @@ test('showStartScreen renders menu and resets state', () => {
   const content = dom.window.document.getElementById('content-window').innerHTML;
   expect(content).toMatch('New Game');
   expect(dom.window.GameState.isCharacterCreated).toBe(false);
+  expect(dom.window.GameState.lastEventTriggered).toBe(null);
 });

--- a/script.js
+++ b/script.js
@@ -126,6 +126,8 @@ function showStartScreen() {
     GameState.currentScene = currentScene;
     previousScreen = null;
     GameState.previousScreen = previousScreen;
+    lastEventTriggered = null;
+    GameState.lastEventTriggered = lastEventTriggered;
 
     const contentWindow = document.getElementById('content-window');
     disableControlWindow();


### PR DESCRIPTION
## Summary
- clear `lastEventTriggered` in `showStartScreen`
- check that the event state resets in unit tests

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684dc27eaf208331b0c758452ea21f08