### PR TITLE
Fix equipment screen with new GameState scoping

### DIFF
--- a/events.js
+++ b/events.js
@@ -1911,7 +1911,7 @@ function displayEventEffect(title, description, message) {
 }
 
 function confirmAugmentEquipmentWithItems(slot) {
-    const item = equippedItems[slot];
+    const item = GameState.equippedItems[slot];
     if (!item) {
         displayNotification("No item equipped in this slot.");
         return;
@@ -1942,7 +1942,7 @@ function confirmAugmentEquipmentWithItems(slot) {
 }
 
 function augmentEquipmentFromEvent(slot, requiredItemName, requiredQuantity) {
-    const item = equippedItems[slot];
+    const item = GameState.equippedItems[slot];
     if (!item) {
         displayNotification("No item equipped in this slot.");
         return;

--- a/inventory.js
+++ b/inventory.js
@@ -1,7 +1,6 @@
 let equipmentInventory = [];
 GameState.inventory = GameState.inventory || [];
 let inventory = GameState.inventory;
-let equippedItems = GameState.equippedItems;
 
 function addItemToInventory(item) {
     const existingItem = inventory.find(i => i.name === item.name);
@@ -15,23 +14,23 @@ function addItemToInventory(item) {
 
 function getEquipmentContent() {
     let equipmentHtml = '<div class="left-justify"><h2>Equipment</h2><ul>';
-    if (equippedItems.weapon || equippedItems.armor) {
-        if (equippedItems.weapon) {
+    if (GameState.equippedItems.weapon || GameState.equippedItems.armor) {
+        if (GameState.equippedItems.weapon) {
             equipmentHtml += `
                 <li>
-                    <strong>${equippedItems.weapon.name}</strong><br>
-                    Attribute: ${equippedItems.weapon.attribute}<br>
-                    Special: ${equippedItems.weapon.special ? equippedItems.weapon.special : "None"}<br>
+                    <strong>${GameState.equippedItems.weapon.name}</strong><br>
+                    Attribute: ${GameState.equippedItems.weapon.attribute}<br>
+                    Special: ${GameState.equippedItems.weapon.special ? GameState.equippedItems.weapon.special : "None"}<br>
                     <button onclick="unequipItem('weapon')">Unequip</button>
                 </li>
             `;
         }
-        if (equippedItems.armor) {
+        if (GameState.equippedItems.armor) {
             equipmentHtml += `
                 <li>
-                    <strong>${equippedItems.armor.name}</strong><br>
-                    Attribute: ${equippedItems.armor.attribute}<br>
-                    Special: ${equippedItems.armor.special ? equippedItems.armor.special : "None"}<br>
+                    <strong>${GameState.equippedItems.armor.name}</strong><br>
+                    Attribute: ${GameState.equippedItems.armor.attribute}<br>
+                    Special: ${GameState.equippedItems.armor.special ? GameState.equippedItems.armor.special : "None"}<br>
                     <button onclick="unequipItem('armor')">Unequip</button>
                 </li>
             `;
@@ -254,17 +253,17 @@ function equipItem(itemName) {
     }
 
     if (item.types && Array.isArray(item.types) && item.types.includes('Weapon')) {
-        if (equippedItems.weapon) {
-            addItemToInventory(equippedItems.weapon);
-            removeEquipmentEffects(equippedItems.weapon);
+        if (GameState.equippedItems.weapon) {
+            addItemToInventory(GameState.equippedItems.weapon);
+            removeEquipmentEffects(GameState.equippedItems.weapon);
         }
-        equippedItems.weapon = { ...item, quantity: 1 }; // Equip one item
+        GameState.equippedItems.weapon = { ...item, quantity: 1 }; // Equip one item
     } else if (item.types && Array.isArray(item.types) && item.types.includes('Armor')) {
-        if (equippedItems.armor) {
-            addItemToInventory(equippedItems.armor);
-            removeEquipmentEffects(equippedItems.armor);
+        if (GameState.equippedItems.armor) {
+            addItemToInventory(GameState.equippedItems.armor);
+            removeEquipmentEffects(GameState.equippedItems.armor);
         }
-        equippedItems.armor = { ...item, quantity: 1 }; // Equip one item
+        GameState.equippedItems.armor = { ...item, quantity: 1 }; // Equip one item
     }
 
     applyEquipmentEffects(item);
@@ -289,11 +288,11 @@ function removeItemFromInventory(item) {
 }
 
 function unequipItem(slot) {
-    const item = equippedItems[slot];
+    const item = GameState.equippedItems[slot];
     if (item) {
         removeEquipmentEffects(item);
         addItemToInventory(item);
-        equippedItems[slot] = null;
+        GameState.equippedItems[slot] = null;
         displayNotification(`You unequipped ${item.name}.`);
         updatePlayerStats(playerStats);
     }

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -58,7 +58,6 @@ function loadGame() {
         GameState.inventory = loadedInventory;
         inventory = GameState.inventory;
         GameState.equippedItems = loadedEquippedItems || { weapon: null, armor: null };
-        equippedItems = GameState.equippedItems;
         currentScene = loadedCurrentScene;
         GameState.currentScene = currentScene;
         eventInProgress = loadedEventInProgress;

--- a/script.js
+++ b/script.js
@@ -252,7 +252,8 @@ function startGame() {
 
     // Initialize player stats, inventory, and equipment
     initializePlayerStats(playerName, playerClass);
-    inventory = []; // Clear the inventory
+    inventory = [];
+    GameState.inventory = inventory;
     GameState.equippedItems = { weapon: null, armor: null }; // Reset equipped items
     generateMap(); // Ensure map is generated here
     displayMap(); // Display map after generating
@@ -912,6 +913,7 @@ function restartGame() {
 
     // Reset inventory and equipmentInventory by clearing their contents
     inventory.length = 0;
+    GameState.inventory = inventory;
     equipmentInventory.length = 0;
     GameState.equippedItems.armor = null;
     GameState.equippedItems.weapon = null;

--- a/towns.js
+++ b/towns.js
@@ -324,7 +324,7 @@ function visitBlacksmith() {
 }
 
 function confirmAugmentWeapon() {
-    const weapon = equippedItems.weapon;
+    const weapon = GameState.equippedItems.weapon;
     if (!weapon) {
         displayNotification("No weapon equipped.");
         return;
@@ -346,7 +346,7 @@ function confirmAugmentWeapon() {
 }
 
 function confirmAugmentArmor() {
-    const armor = equippedItems.armor;
+    const armor = GameState.equippedItems.armor;
     if (!armor) {
         displayNotification("No armor equipped.");
         return;
@@ -369,7 +369,7 @@ function confirmAugmentArmor() {
 
 function augmentWeapon() {
     const contentWindow = document.getElementById('content-window');
-    const weapon = equippedItems.weapon;
+    const weapon = GameState.equippedItems.weapon;
     if (!weapon) {
         displayNotification("No weapon equipped.");
         return;
@@ -395,7 +395,7 @@ function augmentWeapon() {
 
 function augmentArmor() {
     const contentWindow = document.getElementById('content-window');
-    const armor = equippedItems.armor;
+    const armor = GameState.equippedItems.armor;
     if (!armor) {
         displayNotification("No armor equipped.");
         return;


### PR DESCRIPTION
## Summary
- remove global `equippedItems` variable
- reference `GameState.equippedItems` everywhere
- keep GameState inventory synced when starting or restarting a game

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc6f8de0c83319d552cff6d4bf193