### PR TITLE
Use event metadata from JSON and actions map

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -336,6 +336,13 @@
             "terrain": [
                 "treasury"
             ]
+        },
+        {
+            "name": "Treasure Map",
+            "description": "You follow an old map to a stash of valuables.",
+            "effect": "treasure_map",
+            "weight": 1,
+            "terrain": ["forest", "field"]
         }
     ],
     "questEvents": [


### PR DESCRIPTION
## Summary
- add `eventActions` to map event names to handlers
- generate actions for all events and invoke via metadata
- return events with bound actions in `getRandomEvent` functions
- store new `Treasure Map` event in `events.json`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ddedf28fc8331be949d8654ea82e4