### PR TITLE
Add ESLint configuration and update docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+seedrandom.min.js
+holysmokesbatty.ttf

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+    "env": {
+        "browser": true,
+        "node": true,
+        "es2021": true,
+        "jest": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": ["error", 4],
+        "semi": ["error", "always"]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ following steps demonstrate how to verify that dungeon quest events, such as
 
 These steps confirm that dungeon quest events are included when their
 corresponding quest is active.
+
+## Contributing
+
+Before submitting changes, make sure to install dependencies and run the linter and test suite:
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+This helps keep the codebase consistent and ensures tests continue to pass.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "Echoes of The Darkwood",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint ."
   },
   "devDependencies": {
+    "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "jsdom": "^22.1.0"
   }


### PR DESCRIPTION
## Summary
- add ESLint with 4-space indent and semicolons
- ignore vendor assets in ESLint
- provide `npm run lint` script
- document linting in the contribution guidelines

## Testing
- `npm test`
- `npm run lint` *(fails: GameState.js unused variable, tests indentation)*

------
https://chatgpt.com/codex/tasks/task_e_684de745872c8331bab50ce25a3a3ae5