### PR TITLE
Ensure event effects are case-insensitive

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -54,3 +54,30 @@ describe('event weighting', () => {
         expect(counts.dCommon).toBeGreaterThan(counts.dRare);
     });
 });
+
+describe('executeEventEffect', () => {
+    test('combat effect is case-insensitive', () => {
+        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
+        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
+        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
+            '\n;globalThis.executeEventEffect = executeEventEffect;';
+
+        const combatMock = { startCombat: jest.fn() };
+        const context = {
+            console,
+            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
+            document: { getElementById: () => ({ style: {} }) },
+            combat: combatMock
+        };
+
+        vm.createContext(context);
+        vm.runInContext(seedSrc, context);
+        vm.runInContext(utilsSrc, context);
+        vm.runInContext(eventsSrc, context);
+
+        const event = { name: 'Encounter', effect: 'Combat' };
+        context.executeEventEffect(event);
+
+        expect(combatMock.startCombat).toHaveBeenCalled();
+    });
+});

--- a/events.js
+++ b/events.js
@@ -27,6 +27,9 @@ const eventActions = {};
 
 function registerEventActions(list) {
     list.forEach(event => {
+        if (event.effect) {
+            event.effect = event.effect.toLowerCase();
+        }
         eventActions[event.name] = () => executeEventEffect(event);
     });
 }
@@ -38,7 +41,8 @@ registerEventActions(questEvents);
 function executeEventEffect(event) {
     const amount = event.maxAmount ? getRandomInt(event.minAmount || 0, event.maxAmount) : 0;
     const contentWindow = document.getElementById('content-window');
-    switch (event.effect) {
+    const effect = (event.effect || '').toLowerCase();
+    switch (effect) {
         case 'damage': {
             contentWindow.style.animation = 'pulse-red 1s';
             const { finalAmount } = calculateEventEffect(amount, 'damage');


### PR DESCRIPTION
## Summary
- normalize `event.effect` strings when registering actions
- check effect type in lowercase inside `executeEventEffect`
- add test verifying that an event with `"Combat"` effect triggers combat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684def913e2483319f1117dccaf4a614