### PR TITLE
Handle more event effects

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -80,4 +80,108 @@ describe('executeEventEffect', () => {
 
         expect(combatMock.startCombat).toHaveBeenCalled();
     });
+
+    test('shop effect triggers merchant helpers', () => {
+        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
+        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
+        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
+            '\n;globalThis.executeEventEffect = executeEventEffect;';
+
+        const context = {
+            console,
+            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
+            document: { getElementById: () => ({ style: {}, innerHTML: '' }) },
+            currentMerchantName: ''
+        };
+
+        vm.createContext(context);
+        vm.runInContext(seedSrc, context);
+        vm.runInContext(utilsSrc, context);
+        vm.runInContext(eventsSrc, context);
+
+        context.generateMerchantInventory = jest.fn();
+        context.displayMerchantEncounter = jest.fn();
+
+        const event = { name: 'Merchant', effect: 'Shop' };
+        context.executeEventEffect(event);
+
+        expect(context.generateMerchantInventory).toHaveBeenCalled();
+        expect(context.displayMerchantEncounter).toHaveBeenCalled();
+        expect(context.currentMerchantName).toBe('Merchant');
+    });
+
+    test('quest effect loads notice board', () => {
+        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
+        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
+        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
+            '\n;globalThis.executeEventEffect = executeEventEffect;';
+
+        const context = {
+            console,
+            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
+            document: { getElementById: () => ({ style: {}, innerHTML: '' }) }
+        };
+
+        vm.createContext(context);
+        vm.runInContext(seedSrc, context);
+        vm.runInContext(utilsSrc, context);
+        vm.runInContext(eventsSrc, context);
+
+        context.loadNoticeBoard = jest.fn();
+
+        const event = { name: 'Traveler', effect: 'quest', source: 'road' };
+        context.executeEventEffect(event);
+
+        expect(context.loadNoticeBoard).toHaveBeenCalled();
+    });
+
+    test('augment gear effect confirms augmentation', () => {
+        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
+        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
+        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
+            '\n;globalThis.executeEventEffect = executeEventEffect;';
+
+        const context = {
+            console,
+            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
+            document: { getElementById: () => ({ style: {}, innerHTML: '' }) }
+        };
+
+        vm.createContext(context);
+        vm.runInContext(seedSrc, context);
+        vm.runInContext(utilsSrc, context);
+        vm.runInContext(eventsSrc, context);
+
+        context.confirmAugmentEquipmentWithItems = jest.fn();
+
+        const event = { name: 'Stranger', effect: 'augment gear' };
+        context.executeEventEffect(event);
+
+        expect(context.confirmAugmentEquipmentWithItems).toHaveBeenCalledWith('weapon');
+    });
+
+    test('lose coins or combat effect prompts choice', () => {
+        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
+        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
+        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
+            '\n;globalThis.executeEventEffect = executeEventEffect;';
+
+        const context = {
+            console,
+            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
+            document: { getElementById: () => ({ style: {}, innerHTML: '' }) }
+        };
+
+        vm.createContext(context);
+        vm.runInContext(seedSrc, context);
+        vm.runInContext(utilsSrc, context);
+        vm.runInContext(eventsSrc, context);
+
+        context.promptLoseCoinsOrCombat = jest.fn();
+
+        const event = { name: 'Bandit', effect: 'lose coins or combat', minAmount: 10, maxAmount: 10 };
+        context.executeEventEffect(event);
+
+        expect(context.promptLoseCoinsOrCombat).toHaveBeenCalledWith(10, event);
+    });
 });

--- a/data/events.json
+++ b/data/events.json
@@ -183,7 +183,7 @@
         {
             "name": "Merchant Encounter",
             "description": "You encounter a traveling merchant.",
-            "effect": "Shop",
+            "effect": "shop",
             "weight": 2,
             "terrain": [
                 "path",
@@ -193,7 +193,7 @@
         {
             "name": "Deranged Traveler",
             "description": "You meet a deranged traveler on the road.",
-            "effect": "Quest",
+            "effect": "quest",
             "weight": 1,
             "terrain": [
                 "path",
@@ -203,7 +203,7 @@
         {
             "name": "Mysterious Stranger",
             "description": "You meet a mysterious stranger who offers to augment your equipment.",
-            "effect": "Augment gear",
+            "effect": "augment gear",
             "weight": 1,
             "terrain": [
                 "path",
@@ -224,7 +224,7 @@
         {
             "name": "Encounter",
             "description": "You encounter a wild beast.",
-            "effect": "Combat",
+            "effect": "combat",
             "weight": 6,
             "terrain": [
                 "forest",
@@ -238,7 +238,7 @@
         {
             "name": "Bandit Ambush",
             "description": "You are ambushed by bandits demanding your valuables.",
-            "effect": "Lose Coins or Combat",
+            "effect": "lose coins or combat",
             "weight": 1,
             "terrain": [
                 "path",
@@ -250,7 +250,7 @@
         {
             "name": "Encounter",
             "description": "You encounter a wild beast.",
-            "effect": "Combat",
+            "effect": "combat",
             "weight": 6,
             "terrain": [
                 "ruin",


### PR DESCRIPTION
## Summary
- extend event effects in `events.js` for shop, quest, augment gear and lose coins cases
- normalize effect names to lower case in `data/events.json`
- add helper for paying bandits or fighting
- expand `events.test.js` to cover new cases

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684df252a02c833196735cea1aef2c12