### PR TITLE
Fix quest event notice board

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -128,11 +128,13 @@ describe('executeEventEffect', () => {
         vm.runInContext(eventsSrc, context);
 
         context.loadNoticeBoard = jest.fn();
+        context.displayNotification = jest.fn();
 
         const event = { name: 'Traveler', effect: 'quest', source: 'road' };
         context.executeEventEffect(event);
 
-        expect(context.loadNoticeBoard).toHaveBeenCalled();
+        expect(context.loadNoticeBoard).not.toHaveBeenCalled();
+        expect(context.displayNotification).toHaveBeenCalled();
     });
 
     test('augment gear effect confirms augmentation', () => {

--- a/events.js
+++ b/events.js
@@ -118,8 +118,8 @@ function executeEventEffect(event) {
             break;
         }
         case 'quest': {
-            if (typeof loadNoticeBoard === 'function') {
-                loadNoticeBoard(contentWindow, event.source || 'Wilderness');
+            if (event.source && event.source.startsWith('town') && typeof loadNoticeBoard === 'function') {
+                loadNoticeBoard(contentWindow, event.source);
             } else if (typeof displayNotification === 'function') {
                 displayNotification('No notice board available.');
             }


### PR DESCRIPTION
## Summary
- restrict quest events from opening a notice board outside towns
- adjust tests to match new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df75d516c8331bbb480c9f9843097