### PR TITLE
Fix extraneous notice board event

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -110,32 +110,6 @@ describe('executeEventEffect', () => {
         expect(context.currentMerchantName).toBe('Merchant');
     });
 
-    test('quest effect loads notice board', () => {
-        const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');
-        const utilsSrc = fs.readFileSync(path.join(__dirname, '../utils.js'), 'utf8');
-        const eventsSrc = fs.readFileSync(path.join(__dirname, '../events.js'), 'utf8') +
-            '\n;globalThis.executeEventEffect = executeEventEffect;';
-
-        const context = {
-            console,
-            EVENTS_DATA: { events: [], dungeonEvents: [], questEvents: [] },
-            document: { getElementById: () => ({ style: {}, innerHTML: '' }) }
-        };
-
-        vm.createContext(context);
-        vm.runInContext(seedSrc, context);
-        vm.runInContext(utilsSrc, context);
-        vm.runInContext(eventsSrc, context);
-
-        context.loadNoticeBoard = jest.fn();
-        context.displayNotification = jest.fn();
-
-        const event = { name: 'Traveler', effect: 'quest', source: 'road' };
-        context.executeEventEffect(event);
-
-        expect(context.loadNoticeBoard).not.toHaveBeenCalled();
-        expect(context.displayNotification).toHaveBeenCalled();
-    });
 
     test('augment gear effect confirms augmentation', () => {
         const seedSrc = fs.readFileSync(path.join(__dirname, '../seedrandom.min.js'), 'utf8');

--- a/data/events.json
+++ b/data/events.json
@@ -191,16 +191,6 @@
             ]
         },
         {
-            "name": "Deranged Traveler",
-            "description": "You meet a deranged traveler on the road.",
-            "effect": "quest",
-            "weight": 1,
-            "terrain": [
-                "path",
-                "forest"
-            ]
-        },
-        {
             "name": "Mysterious Stranger",
             "description": "You meet a mysterious stranger who offers to augment your equipment.",
             "effect": "augment gear",

--- a/events.js
+++ b/events.js
@@ -117,14 +117,6 @@ function executeEventEffect(event) {
             }
             break;
         }
-        case 'quest': {
-            if (event.source && event.source.startsWith('town') && typeof loadNoticeBoard === 'function') {
-                loadNoticeBoard(contentWindow, event.source);
-            } else if (typeof displayNotification === 'function') {
-                displayNotification('No notice board available.');
-            }
-            break;
-        }
         case 'find': {
             displayEventEffect(event.name, event.description, 'You found what you were looking for.');
             checkQuestCompletion(event);


### PR DESCRIPTION
## Summary
- remove `Deranged Traveler` from event data
- delete `quest` event logic
- drop obsolete notice board test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df992712c8331ad72f738161b6529